### PR TITLE
Fix missing component imports in inventory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,8 @@
       "@/types/*": ["src/types/*"],
       "@/lib/*": ["src/lib/*"],
       "@/styles/*": ["src/styles/*"],
-      "@/assets/*": ["src/assets/*"]
+      "@/assets/*": ["src/assets/*"],
+      "@/services/*": ["src/services/*"]
     }
   },
   "include": ["src"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
       '@/lib': path.resolve(__dirname, './src/lib'),
       '@/styles': path.resolve(__dirname, './src/styles'),
       '@/assets': path.resolve(__dirname, './src/assets'),
+      '@/services': path.resolve(__dirname, './src/services'),
     }
   },
   build: {


### PR DESCRIPTION
Add missing `@/services` alias to Vite and TypeScript configurations to resolve import errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca421c2f-5d47-45e3-b732-1c7233934034">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca421c2f-5d47-45e3-b732-1c7233934034">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>